### PR TITLE
patch for amcvideodec: add property to control frame droppin

### DIFF
--- a/recipes/gst-plugins-bad-1.0.recipe
+++ b/recipes/gst-plugins-bad-1.0.recipe
@@ -76,7 +76,8 @@ class Recipe(custom.GStreamer):
         # 'gst-plugins-bad-1.0/0001-opensles-add-48k-audio-caps.patch',
         'gst-plugins-bad-1.0/0002-Avoid-issues-with-buffer-cleanup-while-flushing.patch',
         'gst-plugins-bad-1.0/0003-sdpdemux-Add-property-to-disable-RTCP.patch',
-        'gst-plugins-bad-1.0/0004-Shot-in-the-dark-fix-for-tinyalsa-blocking.patch'
+        'gst-plugins-bad-1.0/0004-Shot-in-the-dark-fix-for-tinyalsa-blocking.patch',
+        'gst-plugins-bad-1.0/0005-amcvideodec-add-property-to-control-frame-droppin.patch'
     ]
 
     files_lang = ['gst-plugins-bad-1.0']

--- a/recipes/gst-plugins-bad-1.0/0005-amcvideodec-add-property-to-control-frame-droppin.patch
+++ b/recipes/gst-plugins-bad-1.0/0005-amcvideodec-add-property-to-control-frame-droppin.patch
@@ -1,0 +1,131 @@
+From 36964d37a5142044a61993ac0f5cd8ccd9404bca Mon Sep 17 00:00:00 2001
+From: Mark Fernie <39318992+drmarkfernie@users.noreply.github.com>
+Date: Fri, 10 Dec 2021 16:20:09 +1100
+Subject: [PATCH] amcvideodec: add property to control frame droppin
+
+---
+ sys/androidmedia/gstamcvideodec.c | 60 +++++++++++++++++++++++++++++--
+ sys/androidmedia/gstamcvideodec.h |  4 +++
+ 2 files changed, 62 insertions(+), 2 deletions(-)
+
+diff --git a/sys/androidmedia/gstamcvideodec.c b/sys/androidmedia/gstamcvideodec.c
+index d880c58..7e46c2e 100644
+--- a/sys/androidmedia/gstamcvideodec.c
++++ b/sys/androidmedia/gstamcvideodec.c
+@@ -255,9 +255,13 @@ static void
+ gst_amc_video_dec_on_frame_available (JNIEnv * env, jobject thiz,
+     long long context, jobject surfaceTexture);
+ 
++/* properties */
++#define DEFAULT_DROP_FRAMES       TRUE
++
+ enum
+ {
+-  PROP_0
++  PROP_0,
++  PROP_DROP_FRAMES,
+ };
+ 
+ /* class initialization */
+@@ -338,6 +342,38 @@ caps_to_mime (GstCaps * caps)
+   return NULL;
+ }
+ 
++static void
++gst_amc_video_dec_get_property (GObject * object, guint property_id,
++    GValue * value, GParamSpec * pspec)
++{
++  GstAmcVideoDec *decoder = GST_AMC_VIDEO_DEC (object);
++
++  switch (property_id) {
++    case PROP_DROP_FRAMES:
++      g_value_set_boolean (value, decoder->drop_frames);
++      break;
++    default:
++      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
++      break;
++  }
++}
++
++static void
++gst_amc_video_dec_set_property (GObject * object, guint property_id,
++    const GValue * value, GParamSpec * pspec)
++{
++  GstAmcVideoDec *decoder = GST_AMC_VIDEO_DEC (object);
++
++  switch (property_id) {
++    case PROP_DROP_FRAMES:
++      decoder->drop_frames = g_value_get_boolean (value);
++      break;
++    default:
++      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
++      break;
++  }
++}
++
+ static void
+ gst_amc_video_dec_base_init (gpointer g_class)
+ {
+@@ -396,8 +432,25 @@ gst_amc_video_dec_class_init (GstAmcVideoDecClass * klass)
+ 
+   parent_class = g_type_class_peek_parent (klass);
+ 
++  gobject_class->set_property = gst_amc_video_dec_set_property;
++  gobject_class->get_property = gst_amc_video_dec_get_property;
+   gobject_class->finalize = gst_amc_video_dec_finalize;
+ 
++  /**
++   * AmcVideoDec:drop-frames:
++   *
++   * If set to %TRUE the decoder will drop late frames (DEFAULT behaviour).
++   * For Live streams (e.g HLS) it is beneficial to set this false,
++   * otherwise clock-drift appears to trigger the decode to drop frames it considers late.
++   *
++   * Since: 1.16.2 VIVI-ONLY
++   */
++
++  g_object_class_install_property (gobject_class, PROP_DROP_FRAMES,
++      g_param_spec_boolean ("drop-frames", "Drop Old Frames",
++          "Drop Frames which have negative deadline for display",
++          DEFAULT_DROP_FRAMES, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
++
+   element_class->change_state =
+       GST_DEBUG_FUNCPTR (gst_amc_video_dec_change_state);
+   element_class->set_context =
+@@ -430,6 +483,9 @@ gst_amc_video_dec_init (GstAmcVideoDec * self)
+   g_cond_init (&self->gl_cond);
+ 
+   self->gl_queue = g_queue_new ();
++
++  /* Properties */
++  self->drop_frames = DEFAULT_DROP_FRAMES;
+ }
+ 
+ static gboolean
+@@ -1414,7 +1470,7 @@ retry:
+ 
+   is_eos = ! !(buffer_info.flags & BUFFER_FLAG_END_OF_STREAM);
+ 
+-  if (frame
++  if (frame && self->drop_frames
+       && (deadline =
+           gst_video_decoder_get_max_decode_time (GST_VIDEO_DECODER (self),
+               frame)) < 0) {
+diff --git a/sys/androidmedia/gstamcvideodec.h b/sys/androidmedia/gstamcvideodec.h
+index 039a785..d3d8d29 100644
+--- a/sys/androidmedia/gstamcvideodec.h
++++ b/sys/androidmedia/gstamcvideodec.h
+@@ -74,6 +74,10 @@ struct _GstAmcVideoDec
+   guint width;
+   guint height;
+ 
++  /* Property for dropping frames if they are late
++   */
++  gboolean drop_frames;
++
+   guint8 *codec_data;
+   gsize codec_data_size;
+   /* TRUE if the component is configured and saw
+-- 
+2.17.1
+


### PR DESCRIPTION
This is to fix an issue with HLS streams where the decoder (incorrectly) believes
the frames are late and drops them. This leads to choppy playback.